### PR TITLE
update renderer sRGBEncoding

### DIFF
--- a/src/worker/scene/renderer.ts
+++ b/src/worker/scene/renderer.ts
@@ -1,11 +1,13 @@
 import { WebGLRenderer } from 'three';
+import * as THREE from 'three';
 
 export let renderer: WebGLRenderer | undefined;
 
 export function init(canvas: HTMLCanvasElement | OffscreenCanvas) {
-  if (!renderer) renderer = new WebGLRenderer({
-    antialias: true,
-    canvas,
-  });
-  return renderer;
+	if (!renderer) renderer = new WebGLRenderer({
+		antialias: true,
+		canvas,
+	});
+	renderer.outputEncoding = THREE.sRGBEncoding;
+	return renderer;
 }


### PR DESCRIPTION
vrm 1.0 support for model color

## ref

Starting from Three.js r152, you no longer have to specify the color space explicitly. See https://github.com/mrdoob/three.js/pull/25756 for details.

The previous guide before r152
You should enable the linear workflow.

```ts
renderer.outputEncoding = THREE.sRGBEncoding;
```

https://github.com/pixiv/three-vrm/blob/dev/docs/migration-guide-1.0.md#linear-workflows